### PR TITLE
adiciona componente container, ajusta responsividade

### DIFF
--- a/src/components/shared/Container.tsx
+++ b/src/components/shared/Container.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+import React from "react";
+
+interface containerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Container({ children, className }: containerProps) {
+  return (
+    <div className={cn("max-w-[1300px] px-8 mx-auto", className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -1,23 +1,24 @@
-import { Link } from 'react-router-dom';
-import { MobileNavBar } from './MobileNavBar';
-import { NavBar } from './NavBar';
+import { Link } from "react-router-dom";
+import { MobileNavBar } from "./MobileNavBar";
+import { NavBar } from "./NavBar";
+import { Container } from "./container";
 
 export function Header() {
   return (
-    <header className="flex h-16 w-full items-center justify-around px-3">
-      <Link to="/">
-        <img
-          width={64}
-          height={64}
-          src="/vite.svg"
-          className="h-8 w-auto max-sm:h-6"
-          alt="logo"
-        />
-      </Link>
-      <NavBar />
-      <div className="flex items-center justify-center gap-4">
-        <MobileNavBar />
-      </div>
-    </header>
+    <Container>
+      <header className="flex h-16 w-full items-center justify-between">
+        <Link to="/">
+          <img
+            width={64}
+            height={64}
+            src="/vite.svg"
+            className="h-8 w-auto max-sm:h-6"
+            alt="logo"
+          />
+        </Link>
+        <NavBar />
+        <MobileNavBar /> {/* its hidden until the width got 768px */}
+      </header>
+    </Container>
   );
 }

--- a/src/components/shared/events/EventCard.tsx
+++ b/src/components/shared/events/EventCard.tsx
@@ -1,5 +1,5 @@
-import { MapPin } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { MapPin } from "lucide-react";
+import { Link } from "react-router-dom";
 
 interface EventCardProps {
   slug: string;
@@ -19,16 +19,18 @@ export function EventCard({
   return (
     <Link
       to={`/eventos/${slug}`}
-      className="flex h-[248px] flex-col overflow-hidden rounded-md border shadow-md sm:w-[200px] md:w-[288px]"
+      className="flex h-fit flex-col overflow-hidden rounded-md border shadow-md "
     >
       <img
-        className="rounded-t-md transition-transform duration-300 hover:scale-110 sm:h-[100px] md:h-[116px]"
+        className="rounded-t-md transition-transform duration-300 hover:scale-110"
         src={image_url}
         alt={name}
       />
       <div className="flex h-full flex-col justify-between gap-2 p-3">
         <span className="text-sm font-medium">{date}</span>
-        <h1 className="text-lg font-semibold leading-tight">{name}</h1>
+        <h1 className="text-lg font-semibold leading-tight min-h-11 max-h-11 overflow-hidden overflow-ellipsis line-clamp-2">
+          {name}
+        </h1>
         <span className="flex items-center gap-1 text-sm font-light">
           <MapPin strokeWidth={1} size={20} /> {location}
         </span>

--- a/src/components/shared/payments/PaymentVoucher.tsx
+++ b/src/components/shared/payments/PaymentVoucher.tsx
@@ -2,7 +2,7 @@ import { Files } from "lucide-react";
 
 export function PaymentVoucher() {
   return (
-    <div className="flex w-full flex-col items-center justify-between gap-4 rounded-md border-2 bg-white p-8 shadow-md sm:w-[60%]">
+    <div className="flex w-fit flex-col h-fit items-center justify-between gap-4 rounded-md border-2 bg-white p-8 shadow-md">
       <h1 className="text-center text-3xl font-semibold">
         Comprovante de inscricao para o evento: <br /> <b>VI SEMAD</b>
       </h1>
@@ -12,20 +12,16 @@ export function PaymentVoucher() {
             <b>Nome: </b> Yuri Monteiro
           </span>
           <span className="text-left">
-            {" "}
             <b>E-mail:</b> yuri@gmail.com
           </span>
           <span className="text-left">
-            {" "}
             <b>Telefone:</b> 83 99991-8888
           </span>
           <span className="text-left">
-            {" "}
             <b>Instiuição:</b> UEPB
           </span>
           <span className="text-left">
-            {" "}
-            <b>Status do pagamento:</b>{" "}
+            <b>Status do pagamento:</b>
             <span className="rounded-md bg-green-500 p-1 font-mono text-sm font-semibold uppercase text-white">
               REALIZADO
             </span>
@@ -39,7 +35,6 @@ export function PaymentVoucher() {
             alt="qr code"
           />
           <button className="button-primary flex items-center gap-2">
-            {" "}
             <Files /> copiar e colar
           </button>
         </div>

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -1,6 +1,6 @@
+import { Container } from "@/components/shared/container";
 import { Header } from "@/components/shared/Header";
 import { Link, useParams } from "react-router-dom";
-
 
 export function Event() {
   const { slug } = useParams<{ slug: string }>();
@@ -8,41 +8,42 @@ export function Event() {
   return (
     <>
       <Header />
-      <main className="flex min-h-dvh w-full flex-col items-center gap-4 bg-accent px-4 sm:px-[15%] pb-16 pt-8">
-        <img
-          className="sm:h-[388px] w-full h-[180px] rounded-md border-2 shadow-md"
-          src="https://even3.blob.core.windows.net/banner/CAPAPARASITE.72d02a733c034fb18316.png"
-          width={160}
-        />
-        <div className="rounded-md border-2 bg-white p-8 shadow-md">
-          <h1 className="text-center text-3xl font-semibold">
-            IX Seminário Internacional de Habilidades Sociais
-          </h1>
-          <h3 className="text-center text-sm font-medium">
-            I Congresso de Internacional de Relações Interpessoais e Habilidades
-            Sociais
-          </h3>
-          <p className="my-3 text-xl">
-            É com grande entusiasmo que anunciamos o 9º Seminário Internacional
-            de Habilidades Sociais (SIHS) e o 1º Congresso Internacional de
-            Relações Interpessoais e Habilidades Sociais, que acontecerá de 25 a
-            27 de setembro de 2024 na cidade de João Pessoa, Paraíba.
-          </p>
-          <h2 className="text-2xl font-semibold">Sobre o evento</h2>
-          <p className="my-3 text-xl">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Asperiores
-            <strong> error corporis </strong>dicta ad id nam quis eveniet
-            placeat obcaecati, nesciunt alias officiis quam non omnis explicabo
-            recusandae officia natus illo?
-          </p>
-        </div>
-      </main>
-      <Link
-        to={`/eventos/${slug}/inscricao`}
-        className="button-primary fixed sm:bottom-16 bottom-8 right-8"
-      >
-        Increve-se
-      </Link>
+      <Container>
+        <main className="flex min-h-dvh w-full flex-col items-end gap-4 pb-16 pt-8">
+          <img
+            className="sm:h-[388px] w-full h-[180px] rounded-md border-2 shadow-md bg-"
+            src="https://even3.blob.core.windows.net/banner/CAPAPARASITE.72d02a733c034fb18316.png"
+            width={160}
+          />
+          <div className="rounded-md border-2 bg-white p-8 shadow-md">
+            <h1 className="text-center text-3xl font-semibold">
+              IX Seminário Internacional de Habilidades Sociais
+            </h1>
+            <h3 className="text-center text-sm font-medium">
+              I Congresso de Internacional de Relações Interpessoais e
+              Habilidades Sociais
+            </h3>
+            <p className="my-3 text-xl">
+              É com grande entusiasmo que anunciamos o 9º Seminário
+              Internacional de Habilidades Sociais (SIHS) e o 1º Congresso
+              Internacional de Relações Interpessoais e Habilidades Sociais, que
+              acontecerá de 25 a 27 de setembro de 2024 na cidade de João
+              Pessoa, Paraíba.
+            </p>
+            <h2 className="text-2xl font-semibold">Sobre o evento</h2>
+            <p className="my-3 text-xl">
+              Lorem ipsum dolor sit amet consectetur adipisicing elit.
+              Asperiores
+              <strong> error corporis </strong>dicta ad id nam quis eveniet
+              placeat obcaecati, nesciunt alias officiis quam non omnis
+              explicabo recusandae officia natus illo?
+            </p>
+          </div>
+          <Link to={`/eventos/${slug}/inscricao`} className="button-primary">
+            Increva-se
+          </Link>
+        </main>
+      </Container>
     </>
   );
 }

--- a/src/pages/EventsList.tsx
+++ b/src/pages/EventsList.tsx
@@ -23,7 +23,7 @@ export function EventsList() {
             />
             <Search className="absolute right-4" />
           </div>
-          <div className="grid grid-cols-4 place-items-center justify-between gap-10 py-8 max-[1200px]:grid-cols-3 max-[900px]:grid-cols-2 max-sm:grid-cols-1">
+          <div className="grid grid-cols-4 place-items-center justify-between gap-4 py-8 max-[1200px]:grid-cols-3 max-[900px]:grid-cols-2 max-sm:grid-cols-1">
             {events.map((item) => (
               <EventCard
                 key={item.id}

--- a/src/pages/EventsList.tsx
+++ b/src/pages/EventsList.tsx
@@ -1,3 +1,4 @@
+import { Container } from "@/components/shared/container";
 import { EventCard } from "@/components/shared/events/EventCard";
 import { Header } from "@/components/shared/Header";
 import { Input } from "@/components/ui/input";
@@ -11,29 +12,31 @@ export function EventsList() {
   return (
     <>
       <Header />
-      <main className="flex min-h-screen flex-col p-16 max-sm:p-8">
-        <div className="relative flex items-center">
-          <Input
-            type="text"
-            placeholder="Pesquise o evento"
-            //onChange={(e) => setSearchKey(e.target.value)}
-            className="pr-12 focus:!ring-purple-500"
-          />
-          <Search className="absolute right-4" />
-        </div>
-        <div className="grid grid-cols-4 place-items-center justify-between gap-12 py-8 max-[820px]:grid-cols-2 max-sm:grid-cols-1">
-          {events.map((item) => (
-            <EventCard
-              key={item.id}
-              slug={String(item.id)}
-              name={item.name}
-              location={item.location}
-              image_url={item.image_url}
-              date={item.date}
+      <Container>
+        <main className="flex min-h-screen flex-col pt-8">
+          <div className="relative flex items-center">
+            <Input
+              type="text"
+              placeholder="Pesquise o evento"
+              //onChange={(e) => setSearchKey(e.target.value)}
+              className="pr-12 focus:!ring-purple-500"
             />
-          ))}
-        </div>
-      </main>
+            <Search className="absolute right-4" />
+          </div>
+          <div className="grid grid-cols-4 place-items-center justify-between gap-10 py-8 max-[1200px]:grid-cols-3 max-[900px]:grid-cols-2 max-sm:grid-cols-1">
+            {events.map((item) => (
+              <EventCard
+                key={item.id}
+                slug={String(item.id)}
+                name={item.name}
+                location={item.location}
+                image_url={item.image_url}
+                date={item.date}
+              />
+            ))}
+          </div>
+        </main>
+      </Container>
     </>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+import { Container } from "@/components/shared/container";
 import { Header } from "@/components/shared/Header";
 
 export function Home() {
@@ -5,27 +6,30 @@ export function Home() {
   return (
     <>
       <Header />
+
       <main className="flex min-h-screen flex-col">
-        <section className="flex min-h-[calc(100dvh-10rem)] w-full items-center gap-4 p-16 max-md:flex-col-reverse max-sm:p-8 bg-accent">
-          <div className="flex-1">
-            <h1 className="text-7xl font-bold max-sm:text-5xl">
-              Simplificando cada etapa do seu evento
-            </h1>
-            <p className="text-xl font-light max-md:mt-4 max-sm:text-lg">
-              Bem-vindos ao eventflow. Nós somos uma startup dedicada a
-              transformar a maneira como eventos acadêmicos e corporativos são
-              planejados e executados.
-            </p>
-          </div>
-          <div className="flex-1">
-            <img
-              width={64}
-              height={64}
-              className="h-32 w-auto max-md:h-24"
-              src="/vite.svg"
-              alt=""
-            />
-          </div>
+        <section className="flex w-full items-center bg-accent">
+          <Container className="flex gap-8 sm:gap:4 py-28 flex-col-reverse items-center sm:flex-row">
+            <div className="w-full sm:w-[70%]">
+              <h1 className="sm:text-7xl font-bold max-sm:text-4xl max-sm:text-center pb-4">
+                Simplificando cada etapa do seu evento
+              </h1>
+              <p className="text-xl font-light max-md:mt-4 max-sm:text-lg">
+                Bem-vindos ao eventflow. Nós somos uma startup dedicada a
+                transformar a maneira como eventos acadêmicos e corporativos são
+                planejados e executados.
+              </p>
+            </div>
+            <div className="flex-1 flex justify-center items-center">
+              <img
+                width={64}
+                height={64}
+                className="h-32 w-auto max-md:h-24"
+                src="/vite.svg"
+                alt=""
+              />
+            </div>
+          </Container>
         </section>
 
         <div className="flex h-24 items-center justify-around bg-purple-400">
@@ -52,76 +56,80 @@ export function Home() {
           />
         </div>
 
-        <section className="min-h-dvh w-full bg-background p-16 max-sm:p-8">
-          <h1 className="mb-8 text-center text-7xl font-bold max-sm:mb-4 max-sm:text-5xl">
-            Nossos recursos
-          </h1>
-          <div className="grid w-full grid-cols-3 place-items-center gap-8 max-md:grid-cols-1 max-md:gap-4">
-            {[1, 2, 3, 4, 5, 6].map((item) => (
-              <div
-                key={item}
-                className="flex h-[360px] w-[300px] flex-col items-center justify-center gap-2 rounded-md border-2 bg-accent p-3 shadow-md"
-              >
-                <img
-                  width={64}
-                  height={64}
-                  className="h-16 w-16 rounded-full"
-                  src="https://github.com/shadcn.png"
-                  alt="avatar"
-                />
-                <p className="text-center">
-                  Lorem, ipsum dolor sit amet consectetur adipisicing elit.
-                  Laborum, dolores!
-                </p>
-              </div>
-            ))}
-          </div>
+        <section className="min-h-dvh w-full bg-background py-8 sm:py-16">
+          <Container>
+            <h1 className="mb-8 text-center text-7xl font-bold max-sm:text-4xl">
+              Nossos recursos
+            </h1>
+            <div className="grid grid-cols-3 place-items-center  gap-8 max-[990px]:grid-cols-2 max-sm:grid-cols-1 max-md:gap-4">
+              {[1, 2, 3, 4, 5, 6].map((item) => (
+                <div
+                  key={item}
+                  className="flex h-[360px] w-[300px] flex-col items-center justify-center gap-2 rounded-md border-2 bg-accent p-3 shadow-md"
+                >
+                  <img
+                    width={64}
+                    height={64}
+                    className="h-16 w-16 rounded-full"
+                    src="https://github.com/shadcn.png"
+                    alt="avatar"
+                  />
+                  <p className="text-center">
+                    Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+                    Laborum, dolores!
+                  </p>
+                </div>
+              ))}
+            </div>
+          </Container>
         </section>
 
-        <section className="flex w-full items-center gap-4 bg-accent p-16 max-md:flex-col-reverse max-sm:p-8">
-          <div className="flex-1">
-            <img
-              width={64}
-              height={64}
-              className="h-32 w-auto max-md:h-24"
-              src="/vite.svg"
-              alt=""
-            />
-          </div>
-          <div className="flex flex-1 flex-col gap-4">
-            <h1 className="text-center text-6xl font-bold max-sm:text-4xl">
-              Porque escolher o{" "}
-              <strong className="text-purple-400">eventflow</strong>
-            </h1>
-            <p className="text-xl font-light max-md:mt-4 max-sm:text-lg">
-              Bem-vindos ao eventflow! Nós somos uma startup dedicada a
-              transformar a maneira como eventos acadêmicos e corporativos são
-              planejados e executados.
-            </p>
-            <p className="text-xl font-light max-md:mt-4 max-sm:text-lg">
-              Bem-vindos ao eventflow! Nós somos uma startup dedicada a
-              transformar a maneira como eventos acadêmicos e corporativos são
-              planejados e executados.
-            </p>
-            <div className="mt-4 flex flex-wrap items-center justify-center gap-4">
-              <div className="flex w-48 flex-col rounded-md border bg-background p-4 shadow-md">
-                <strong className="text-5xl font-bold">+200</strong>
-                <span>
-                  certificados <br /> gerados
-                </span>
-              </div>
+        <section className=" w-full bg-accent ">
+          <Container className="flex items-center gap-4 p-16 max-[1000px]:flex-col max-sm:p-8">
+            <div className="flex-1 flex justify-center items-center">
+              <img
+                width={500}
+                height={500}
+                className="h-[250px] w-auto max-md:h-24"
+                src="/vite.svg"
+                alt=""
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-4">
+              <h1 className="text-center text-6xl font-bold max-sm:text-4xl">
+                Porque escolher o{' '}
+                <strong className="text-purple-400">eventflow</strong>
+              </h1>
+              <p className="text-xl font-light max-md:mt-4 max-sm:text-lg">
+                Bem-vindos ao eventflow! Nós somos uma startup dedicada a
+                transformar a maneira como eventos acadêmicos e corporativos são
+                planejados e executados.
+              </p>
+              <p className="text-xl font-light max-md:mt-4 max-sm:text-lg">
+                Bem-vindos ao eventflow! Nós somos uma startup dedicada a
+                transformar a maneira como eventos acadêmicos e corporativos são
+                planejados e executados.
+              </p>
+              <div className="mt-4 flex flex-wrap items-center justify-center gap-4 text-center">
+                <div className="flex w-48 flex-col rounded-md border bg-background p-4 shadow-md">
+                  <strong className="text-5xl font-bold">+200</strong>
+                  <span>
+                    certificados <br /> gerados
+                  </span>
+                </div>
 
-              <div className="flex w-48 flex-col rounded-md border bg-background p-4 shadow-md">
-                <strong className="text-5xl font-bold">+1000</strong>
-                <span>Usuarios cadastrados</span>
-              </div>
+                <div className="flex w-48 min-h-32 items-center justify-center flex-col rounded-md border bg-background p-4 shadow-md">
+                  <strong className="text-5xl font-bold">+1000</strong>
+                  <span>Usuarios cadastrados</span>
+                </div>
 
-              <div className="flex w-48 flex-col rounded-md border bg-background p-4 shadow-md">
-                <strong className="text-5xl font-bold">+20</strong>
-                <span>Profissionais certificados</span>
+                <div className="flex w-48 flex-col rounded-md border bg-background p-4 shadow-md">
+                  <strong className="text-5xl font-bold">+20</strong>
+                  <span>Profissionais certificados</span>
+                </div>
               </div>
             </div>
-          </div>
+          </Container>
         </section>
 
         <section className="min-h-dvh w-full bg-background p-16 max-sm:p-8">

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -5,7 +5,7 @@ export function Payment() {
   return (
     <>
       <Header />
-      <main className="flex min-h-[calc(100dvh-4rem)] w-full items-center justify-center bg-accent p-2 md:p-12">
+      <main className="flex min-h-[calc(100dvh-4rem)] w-full justify-center bg-accent p-2 md:p-12">
         <PaymentVoucher />
       </main>
     </>


### PR DESCRIPTION
Esse pull request traz ajustes de responsividade para todas as páginas, onde achei necessário fazer algum ajuste. 
A criação do componente container vai facilitar caso precisemos fazer essas alterações, pois só vamos precisar alterar o estilo aplicado nesse componente.

HD (1920px): 
![image](https://github.com/user-attachments/assets/512ba7f2-81c2-4ee6-9a71-63282423e7f8)

Desk (1366px):
![image](https://github.com/user-attachments/assets/0205a822-3665-464d-aec0-f143d592b9a4)

Tablet (768px): 
![image](https://github.com/user-attachments/assets/b5b27f66-c6af-4465-9a3e-22e1ed7d19cd)

Mobile (414px):
![image](https://github.com/user-attachments/assets/a9c9276a-101a-48d4-a61a-d45687480a40)

Também ajustei os cards da lista de eventos, procurando sempre a melhor exibição possível do conteúdo. 
Também quero dar destaque para alteração que fiz no título dos cards, se o título ocupar mais que 2 linhas ele é substituído por ...
![image](https://github.com/user-attachments/assets/0fdd8717-1bcd-4421-b47c-4efe420e18b4)

