### PR TITLE
fix: ajusta tamanho das imagens de parceiro em telas mobile

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,21 +35,13 @@ export function Home() {
         </section>
 
         <div className="flex h-24 items-center justify-around bg-purple-700">
-          <img
-            className="h-20 w-auto"
-            src={sponsor1}
-            alt=""
-          />
-          <img
-            className="h-16 w-auto"
-            src={sponsor2}
-            alt=""
-          />
-          <img
-            className="h-16 w-auto"
-            src={sponsor3}
-            alt=""
-          />
+          {[sponsor1, sponsor2, sponsor3].map((imageSrc) => {
+            return (<img
+              className="max-h-16 w-1/3 sm:w-auto"
+              src={imageSrc}
+              alt=""
+            />)
+          })}
         </div>
 
         <section className="min-h-dvh w-full bg-background py-8 sm:py-16">


### PR DESCRIPTION
imagens de parceiros estava quebrando no tamanho mobile: 
![image](https://github.com/user-attachments/assets/272f0a8a-6531-4e22-be22-70d14551532c)

ajuste realizado: 
![image](https://github.com/user-attachments/assets/ea33b330-2cee-4435-b487-03ed8b899adb)
